### PR TITLE
Replace emoji with FontAwesome icons in interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^7.0.0",
+        "@fortawesome/free-solid-svg-icons": "^7.0.0",
+        "@fortawesome/react-fontawesome": "^0.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "three": "^0.170.0"
@@ -705,6 +708,52 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.0.tgz",
+      "integrity": "sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
+      "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-njSLAllkOddYDCXgTFboXn54Oe5FcvpkWq+FoetOHR64PbN0608kM02Lze0xtISGpXgP+i26VyXRQA0Irh3Obw==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.3.tgz",
+      "integrity": "sha512-HlJco8RDY8NrzFVjy23b/7mNS4g9NegcrBG3n7jinwpc2x/AmSVk53IhWniLYM4szYLxRAFTAGwGn0EIlclDeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1813,6 +1862,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -1934,6 +1992,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1979,6 +2048,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "vite": "^5.4.10"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.0.0",
+    "@fortawesome/free-solid-svg-icons": "^7.0.0",
+    "@fortawesome/react-fontawesome": "^0.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "three": "^0.170.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faMicrophone } from '@fortawesome/free-solid-svg-icons'
 import MemoryPalace from './components/MemoryPalace'
 import MobileInterface from './components/MobileInterface'
 import VoiceInterface from './components/VoiceInterface'
@@ -65,7 +67,7 @@ function App() {
           onClick={() => handleVoiceToggle(!voiceEnabled)}
           aria-label={voiceEnabled ? 'Disable voice' : 'Enable voice'}
         >
-          🎤
+          <FontAwesomeIcon icon={faMicrophone} />
         </button>
       </div>
     </div>

--- a/src/components/MobileInterface.jsx
+++ b/src/components/MobileInterface.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faMicrophone, faBars, faTimes } from '@fortawesome/free-solid-svg-icons'
 
 const MobileInterface = ({ voiceEnabled, onVoiceToggle }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -23,7 +25,7 @@ const MobileInterface = ({ voiceEnabled, onVoiceToggle }) => {
           onClick={() => onVoiceToggle(!voiceEnabled)}
           aria-label="Toggle voice control"
         >
-          🎤
+          <FontAwesomeIcon icon={faMicrophone} />
         </button>
         
         <button 
@@ -31,7 +33,7 @@ const MobileInterface = ({ voiceEnabled, onVoiceToggle }) => {
           onClick={handleMenuToggle}
           aria-label="Open menu"
         >
-          ☰
+          <FontAwesomeIcon icon={faBars} />
         </button>
       </div>
 
@@ -45,7 +47,7 @@ const MobileInterface = ({ voiceEnabled, onVoiceToggle }) => {
               onClick={() => setIsMenuOpen(false)}
               aria-label="Close menu"
             >
-              ✕
+              <FontAwesomeIcon icon={faTimes} />
             </button>
           </div>
           

--- a/src/components/VoiceInterface.jsx
+++ b/src/components/VoiceInterface.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faMicrophone, faCircle } from '@fortawesome/free-solid-svg-icons'
 
 const VoiceInterface = ({ enabled, isMobile }) => {
   const [isListening, setIsListening] = useState(false)
@@ -111,7 +113,10 @@ const VoiceInterface = ({ enabled, isMobile }) => {
         onTouchEnd={stopListening}
         aria-label="Hold to speak"
       >
-        {isListening ? '🔴' : '🎤'}
+        <FontAwesomeIcon 
+          icon={isListening ? faCircle : faMicrophone}
+          style={{ color: isListening ? '#FF3B30' : 'inherit' }}
+        />
         <span className="voice-control-text">
           {isListening ? 'Listening...' : 'Hold to speak'}
         </span>
@@ -134,9 +139,13 @@ const VoiceInterface = ({ enabled, isMobile }) => {
       {/* Voice Status */}
       <div className="voice-status-info">
         {isSupported ? (
-          <span className="status-supported">🟢 Voice control ready</span>
+          <span className="status-supported">
+            <FontAwesomeIcon icon={faCircle} style={{ color: '#30D158' }} /> Voice control ready
+          </span>
         ) : (
-          <span className="status-unsupported">🔴 Voice control not supported in this browser</span>
+          <span className="status-unsupported">
+            <FontAwesomeIcon icon={faCircle} style={{ color: '#FF3B30' }} /> Voice control not supported in this browser
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
This PR addresses issue #4 by replacing all emoji characters in the interface with FontAwesome icons.

## Changes
- Install FontAwesome React packages
- Replace 🎤 microphone emoji with FontAwesome faMicrophone icon
- Replace 🔴 red circle emoji with FontAwesome faCircle icon (red)
- Replace 🟢 green circle emoji with FontAwesome faCircle icon (green)
- Replace ☰ hamburger menu emoji with FontAwesome faBars icon
- Replace ✕ close button emoji with FontAwesome faTimes icon

Improves cross-browser compatibility and provides more consistent styling.

Closes #4

Generated with [Claude Code](https://claude.ai/code)