### PR TITLE
Fix skybox loading at startup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,21 +32,21 @@ function App() {
     setVoiceEnabled(enabled)
   }
 
-  if (isLoading) {
-    return (
-      <div className="app-loading">
-        <div className="loading-content">
-          <h1>Palais de Mémoire</h1>
-          <div className="loading-spinner"></div>
-          <p>Preparing your immersive memory palace...</p>
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className={`app ${isMobile ? 'mobile' : 'desktop'}`}>
+      {/* Always show the MemoryPalace (skybox) as initial state */}
       <MemoryPalace />
+      
+      {/* Show loading overlay while initializing */}
+      {isLoading && (
+        <div className="app-loading">
+          <div className="loading-content">
+            <h1>Palais de Mémoire</h1>
+            <div className="loading-spinner"></div>
+            <p>Preparing your immersive memory palace...</p>
+          </div>
+        </div>
+      )}
       
       {isMobile && (
         <MobileInterface 

--- a/src/components/MemoryPalace.jsx
+++ b/src/components/MemoryPalace.jsx
@@ -33,27 +33,32 @@ const MemoryPalace = () => {
     const textureLoader = new THREE.TextureLoader()
     let skyboxTexture = null
     
+    // Create material with fallback color initially
+    const material = new THREE.MeshBasicMaterial({
+      color: 0x1a1a2e, // Dark fallback color
+      side: THREE.BackSide
+    })
+    
     try {
       skyboxTexture = textureLoader.load(
         'https://page-images.websim.com/Create_a_360_degree_equirectangular_panoramic_image_in_21_9_aspect_ratio_showing__scene_____TECHNICA_694056a68c0178.jpg',
-        () => {
-          // Texture loaded successfully
-          console.log('Skybox texture loaded')
+        (texture) => {
+          // Texture loaded successfully - update material
+          console.log('Skybox texture loaded successfully')
+          material.map = texture
+          material.color.setHex(0xffffff) // Set to white to show texture properly
+          material.needsUpdate = true
         },
         undefined,
         (error) => {
           console.error('Error loading skybox texture:', error)
+          // Keep the fallback dark color
         }
       )
     } catch (error) {
       console.error('Error creating skybox texture:', error)
+      // Keep the fallback dark color
     }
-    
-    const material = new THREE.MeshBasicMaterial({
-      map: skyboxTexture,
-      color: skyboxTexture ? 0xffffff : 0x1a1a2e,
-      side: THREE.BackSide
-    })
     
     const sphere = new THREE.Mesh(geometry, material)
     scene.add(sphere)

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -13,7 +13,9 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460);
+  background: linear-gradient(135deg, rgba(26, 26, 46, 0.8), rgba(22, 33, 62, 0.8), rgba(15, 52, 96, 0.8));
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,16 @@ export default defineConfig({
   },
   server: {
     port: 3000,
-    host: true
+    host: true,
+    fs: {
+      // Exclude prototype folder to prevent websim dependency issues
+      deny: ['**/prototype/**']
+    }
+  },
+  // Exclude prototype folder from module resolution
+  resolve: {
+    alias: {
+      '/prototype': false
+    }
   }
 })


### PR DESCRIPTION
Implements issue #3 - Fix skybox scene loading at startup

## Changes
- Fix texture loading race condition in MemoryPalace.jsx
- Show skybox immediately at startup instead of hiding behind loading screen
- Make loading overlay semi-transparent so skybox is visible during loading
- Update Vite config to exclude prototype folder from build

## Test Plan
- Run the application and verify skybox appears immediately at startup
- Confirm the panoramic image loads correctly from the specified URL
- Test that loading overlay is visible but doesn't block the skybox
- Verify navigation controls work properly in the skybox environment

Generated with [Claude Code](https://claude.ai/code)