### PR TITLE
feat: implement Anthropic SDK with browser headers and streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.59.0",
         "@fortawesome/fontawesome-svg-core": "^7.0.0",
         "@fortawesome/free-solid-svg-icons": "^7.0.0",
         "@fortawesome/react-fontawesome": "^0.2.3",
@@ -37,6 +38,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.59.0.tgz",
+      "integrity": "sha512-m9w9tC+N+GUNprwEOhU3VKKSYwXA1fIevRCe7kOFonV4xu5vxqmqyoLy+dkdVvc5W1F4WUTVE/7I4criaF9gnw==",
+      "license": "MIT",
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "vite": "^5.4.10"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.59.0",
     "@fortawesome/fontawesome-svg-core": "^7.0.0",
     "@fortawesome/free-solid-svg-icons": "^7.0.0",
     "@fortawesome/react-fontawesome": "^0.2.3",

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,6 @@
+/**
+ * Hooks Index - Export all custom hooks
+ */
+
+export { useAnthropicStream } from './useAnthropicStream.js'
+export { default } from './useAnthropicStream.js'

--- a/src/hooks/useAnthropicStream.js
+++ b/src/hooks/useAnthropicStream.js
@@ -1,0 +1,366 @@
+/**
+ * Anthropic SDK Stream Hook for Memory Palace
+ * Handles streaming conversations with proper browser headers and tool calls
+ */
+
+import { useState, useCallback, useRef, useMemo } from 'react'
+import Anthropic from '@anthropic-ai/sdk'
+import settingsManager from '../services/SettingsManager.js'
+import MemoryPalaceToolManager from '../utils/memoryPalaceTools.js'
+
+export const useAnthropicStream = (onAddMessage, memoryPalaceCore = null) => {
+  const [status, setStatus] = useState('idle') // 'idle' | 'thinking' | 'streaming' | 'tool_use' | 'waiting_for_user'
+  const [liveBlocks, setLiveBlocks] = useState(null)
+  const [pendingTool, setPendingTool] = useState(null)
+  const abortRef = useRef(null)
+
+  // Anthropic SDK instance with proper browser configuration
+  const anthropic = useMemo(() => {
+    const apiKey = settingsManager.get('anthropicApiKey')
+    if (!apiKey) return null
+    
+    return new Anthropic({
+      dangerouslyAllowBrowser: true,
+      apiKey: apiKey,
+      baseURL: 'https://api.anthropic.com',
+      defaultHeaders: {
+        'anthropic-version': '2023-06-01',
+        'anthropic-dangerous-direct-browser-access': 'true',
+      },
+    })
+  }, [settingsManager.get('anthropicApiKey')])
+
+  // Merge delta helper for streaming content
+  const mergeDelta = useCallback((block, delta) => {
+    if (!delta) return
+    
+    switch (delta.type) {
+      case 'text_delta':
+        block.text = (block.text ?? '') + (delta.text ?? '')
+        break
+      case 'input_json_delta':
+        block._input_json_str = (block._input_json_str ?? '') + (delta.partial_json ?? '')
+        break
+      default:
+        console.warn('Unhandled delta type:', delta.type)
+        Object.assign(block, delta)
+    }
+  }, [])
+
+  // Build request body with memory palace context
+  const buildRequestBody = useCallback((messages, context = {}) => {
+    const systemPrompt = buildSystemPrompt(context)
+    
+    // Get available memory palace tools
+    const tools = getMemoryPalaceTools()
+    
+    return {
+      model: settingsManager.get('selectedModel') || 'claude-3-sonnet-20240229',
+      max_tokens: 4000,
+      temperature: settingsManager.get('responseTemperature') || 0.7,
+      stream: true,
+      system: systemPrompt,
+      messages: messages,
+      tools: tools.length > 0 ? tools : undefined,
+    }
+  }, [])
+
+  // Build system prompt with memory palace context
+  const buildSystemPrompt = useCallback((context = {}) => {
+    const basePrompt = settingsManager.get('systemPrompt') || 
+      'You are a Memory Palace AI assistant. Help users create immersive 3D memory spaces using voice commands.'
+    
+    const { currentRoom, rooms = [], objects = [] } = context
+
+    let contextPrompt = basePrompt + '\n\n'
+
+    if (currentRoom) {
+      contextPrompt += `CURRENT ROOM: ${currentRoom.name}\n`
+      contextPrompt += `ROOM DESCRIPTION: ${currentRoom.description}\n`
+    }
+
+    if (rooms.length > 0) {
+      contextPrompt += `\nAVAILABLE ROOMS:\n${rooms.map(room => 
+        `- ${room.name}: ${room.description}`
+      ).join('\n')}\n`
+    }
+
+    if (objects.length > 0) {
+      contextPrompt += `\nOBJECTS IN CURRENT ROOM:\n${objects.map(obj => 
+        `- ${obj.name}: ${obj.info}`
+      ).join('\n')}\n`
+    }
+
+    contextPrompt += `
+MEMORY PALACE TOOLS AVAILABLE:
+- create_room: Create a new memory room
+- edit_room: Modify current room description  
+- go_to_room: Navigate to another room
+- add_object: Add memory object to current room
+- remove_object: Remove object from room
+- list_rooms: Show available rooms
+- get_room_info: Get details about current room
+
+Use these tools to help users build and navigate their memory palace.`
+
+    return contextPrompt
+  }, [])
+
+  // Memory palace tool manager
+  const toolManager = useMemo(() => {
+    return memoryPalaceCore ? new MemoryPalaceToolManager(memoryPalaceCore) : null
+  }, [memoryPalaceCore])
+
+  // Get memory palace tools for Claude
+  const getMemoryPalaceTools = useCallback(() => {
+    return MemoryPalaceToolManager.getToolDefinitions()
+  }, [])
+
+  // Execute memory palace tool calls
+  const executeToolCall = useCallback(async (toolName, input, toolUseId) => {
+    console.log(`[useAnthropicStream] Executing tool: ${toolName}`, input)
+    
+    if (toolManager) {
+      return await toolManager.executeTool(toolName, input, toolUseId)
+    } else {
+      // Fallback responses when memory palace core is not available
+      switch (toolName) {
+        case 'create_room':
+          return `Room creation scheduled: "${input.name}" with description: ${input.description}. Memory Palace core not connected.`
+        
+        case 'edit_room':
+          return `Room editing scheduled: ${input.description}. Memory Palace core not connected.`
+        
+        case 'go_to_room':
+          return `Navigation scheduled to room: ${input.roomName}. Memory Palace core not connected.`
+        
+        case 'add_object':
+          return `Object creation scheduled: "${input.name}" with info: ${input.info}. Memory Palace core not connected.`
+        
+        case 'remove_object':
+          return `Object removal scheduled: ${input.name}. Memory Palace core not connected.`
+        
+        case 'list_rooms':
+          return 'Room listing not available - Memory Palace core not connected.'
+        
+        default:
+          return `Unknown tool: ${toolName}`
+      }
+    }
+  }, [toolManager])
+
+  // Assemble final message from streaming blocks
+  const assembleMessage = useCallback((blocks) => {
+    Object.values(blocks).forEach((block) => {
+      if (block._input_json_str !== undefined) {
+        try {
+          block.input = JSON.parse(block._input_json_str)
+        } catch {
+          // Ignore parse errors
+        }
+        delete block._input_json_str
+      }
+    })
+
+    const content = Object.keys(blocks)
+      .map(Number)
+      .sort((a, b) => a - b)
+      .map((k) => {
+        const { delta, _streaming, ...block } = blocks[k]
+        return block
+      })
+
+    return { role: 'assistant', content }
+  }, [])
+
+  // Stream a single message
+  const streamMessage = useCallback(async (messages, context = {}) => {
+    if (!anthropic) throw new Error('Anthropic API key not configured')
+
+    const body = buildRequestBody(messages, context)
+    console.log('[useAnthropicStream] Request body:', body)
+
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+
+    try {
+      const stream = await anthropic.messages.create(body, {
+        signal: ctrl.signal,
+      })
+
+      const blocks = {}
+      let stopReason = ''
+
+      for await (const event of stream) {
+        console.log('[useAnthropicStream] Stream event:', event.type)
+
+        switch (event.type) {
+          case 'content_block_start':
+            blocks[event.index] = structuredClone(event.content_block)
+            if (blocks[event.index].type === 'text' && blocks[event.index].text === undefined) {
+              blocks[event.index].text = ''
+            }
+            break
+
+          case 'content_block_delta':
+            if (blocks[event.index]) {
+              mergeDelta(blocks[event.index], event.delta)
+            }
+            break
+
+          case 'message_delta':
+            if (event.delta.stop_reason) {
+              stopReason = event.delta.stop_reason
+            }
+            break
+
+          case 'message_stop':
+            break
+
+          case 'error':
+            throw new Error(`Stream error: ${event.error.message}`)
+        }
+
+        // Update live preview
+        if (event.type !== 'message_stop') {
+          const preview = Object.keys(blocks)
+            .map(Number)
+            .sort((a, b) => a - b)
+            .map((k) => ({
+              ...blocks[k],
+              _streaming: k === Math.max(...Object.keys(blocks).map(Number)),
+            }))
+          setLiveBlocks(preview)
+        }
+      }
+
+      const finalMessage = assembleMessage(blocks)
+      return { message: finalMessage, stopReason }
+
+    } catch (error) {
+      console.error('[useAnthropicStream] Streaming error:', error)
+      throw error
+    }
+  }, [anthropic, buildRequestBody, mergeDelta, assembleMessage])
+
+  // Main send function with tool use loop
+  const send = useCallback(async (history, userText, context = {}) => {
+    if (!anthropic) throw new Error('Anthropic API key not configured')
+    if (status !== 'idle') throw new Error('Stream already in progress')
+
+    setStatus('thinking')
+
+    const messages = history
+      .filter((m) => m.role !== 'system')
+      .map((m) => ({ role: m.role, content: m.content }))
+      .concat([{ role: 'user', content: userText }])
+
+    let currentMessages = [...messages]
+    const allNewMessages = []
+
+    try {
+      while (true) {
+        setStatus('streaming')
+
+        const { message, stopReason } = await streamMessage(currentMessages, context)
+
+        // Add assistant message
+        allNewMessages.push(message)
+        currentMessages.push(message)
+
+        if (onAddMessage) {
+          onAddMessage({
+            id: crypto.randomUUID(),
+            role: message.role,
+            content: message.content,
+            timestamp: Date.now(),
+          })
+        }
+
+        if (stopReason === 'tool_use') {
+          setStatus('tool_use')
+
+          // Execute all tool calls
+          const toolResults = []
+          for (const block of message.content) {
+            if (block.type === 'tool_use') {
+              try {
+                const result = await executeToolCall(block.name, block.input, block.id)
+                toolResults.push({
+                  type: 'tool_result',
+                  tool_use_id: block.id,
+                  content: result,
+                })
+              } catch (error) {
+                toolResults.push({
+                  type: 'tool_result',
+                  tool_use_id: block.id,
+                  content: `Error: ${error.message}`,
+                  is_error: true,
+                })
+              }
+            }
+          }
+
+          setLiveBlocks(null)
+
+          const toolResultMessage = {
+            role: 'user',
+            content: toolResults,
+          }
+
+          allNewMessages.push(toolResultMessage)
+          currentMessages.push(toolResultMessage)
+
+          if (onAddMessage) {
+            onAddMessage({
+              id: crypto.randomUUID(),
+              role: toolResultMessage.role,
+              content: toolResultMessage.content,
+              timestamp: Date.now(),
+            })
+          }
+
+          continue
+        } else {
+          break
+        }
+      }
+    } catch (error) {
+      console.error('[useAnthropicStream] Send error:', error)
+      throw error
+    } finally {
+      setStatus('idle')
+      setLiveBlocks(null)
+      setPendingTool(null)
+      abortRef.current = null
+    }
+
+    return allNewMessages
+  }, [anthropic, status, streamMessage, executeToolCall, onAddMessage])
+
+  // Abort helper
+  const abort = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+      abortRef.current = null
+    }
+    setStatus('idle')
+    setLiveBlocks(null)
+    if (pendingTool) {
+      pendingTool.reject(new Error('Aborted by user'))
+      setPendingTool(null)
+    }
+  }, [pendingTool])
+
+  return {
+    status,
+    liveBlocks,
+    pendingTool,
+    send,
+    abort,
+    isConfigured: !!anthropic,
+  }
+}
+
+export default useAnthropicStream

--- a/src/services/AnthropicAPI.js
+++ b/src/services/AnthropicAPI.js
@@ -1,6 +1,13 @@
 /**
- * Anthropic API Service for Claude LLM Integration
- * Handles conversation, command processing, and structured responses
+ * Legacy Anthropic API Service for Claude LLM Integration
+ * 
+ * DEPRECATED: Use useAnthropicStream hook for new implementations
+ * This service is kept for backward compatibility only.
+ * 
+ * New features should use:
+ * - Official @anthropic-ai/sdk
+ * - Streaming support via useAnthropicStream hook
+ * - Proper browser headers and tool calls
  */
 
 import settingsManager from './SettingsManager.js'

--- a/src/services/SettingsManager.js
+++ b/src/services/SettingsManager.js
@@ -17,6 +17,7 @@ export class SettingsManager {
       speechPitch: 1.0,
       
       // AI/LLM Settings
+      selectedModel: 'claude-3-sonnet-20240229',
       systemPrompt: `You are a Memory Palace AI assistant. Help users create immersive 3D memory spaces using voice commands. Process commands for creating rooms, adding objects, and navigating between memory spaces. Be conversational and supportive.`,
       responseTemperature: 0.7,
       
@@ -292,7 +293,8 @@ export class SettingsManager {
     return {
       'Content-Type': 'application/json',
       'x-api-key': this.settings.anthropicApiKey,
-      'anthropic-version': '2023-06-01'
+      'anthropic-version': '2023-06-01',
+      'anthropic-dangerous-direct-browser-access': 'true'
     }
   }
 

--- a/src/utils/memoryPalaceTools.js
+++ b/src/utils/memoryPalaceTools.js
@@ -1,0 +1,327 @@
+/**
+ * Memory Palace Tools Integration
+ * Handles tool execution for memory palace operations via Claude
+ */
+
+export class MemoryPalaceToolManager {
+  constructor(memoryPalaceCore) {
+    this.core = memoryPalaceCore
+    this.roomManager = memoryPalaceCore?.roomManager
+    this.objectManager = memoryPalaceCore?.objectManager
+  }
+
+  /**
+   * Execute a memory palace tool call
+   */
+  async executeTool(toolName, input, toolUseId) {
+    console.log(`[MemoryPalaceTools] Executing ${toolName}`, input)
+
+    try {
+      switch (toolName) {
+        case 'create_room':
+          return await this.createRoom(input)
+        
+        case 'edit_room':
+          return await this.editRoom(input)
+        
+        case 'go_to_room':
+          return await this.goToRoom(input)
+        
+        case 'add_object':
+          return await this.addObject(input)
+        
+        case 'remove_object':
+          return await this.removeObject(input)
+        
+        case 'list_rooms':
+          return await this.listRooms()
+        
+        case 'get_room_info':
+          return await this.getRoomInfo()
+        
+        default:
+          throw new Error(`Unknown tool: ${toolName}`)
+      }
+    } catch (error) {
+      console.error(`[MemoryPalaceTools] Error executing ${toolName}:`, error)
+      throw error
+    }
+  }
+
+  /**
+   * Create a new room
+   */
+  async createRoom({ name, description }) {
+    if (!this.roomManager) {
+      return `Room creation not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const room = await this.roomManager.createRoom({
+        name,
+        description,
+        position: { x: 0, y: 0, z: 0 } // Default position
+      })
+      
+      return `Successfully created room "${name}" with description: ${description}`
+    } catch (error) {
+      return `Failed to create room "${name}": ${error.message}`
+    }
+  }
+
+  /**
+   * Edit current room description
+   */
+  async editRoom({ description }) {
+    if (!this.roomManager) {
+      return `Room editing not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const currentRoom = this.roomManager.getCurrentRoom()
+      if (!currentRoom) {
+        return `No current room to edit`
+      }
+
+      await this.roomManager.updateRoom(currentRoom.id, { description })
+      return `Successfully updated room description to: ${description}`
+    } catch (error) {
+      return `Failed to edit room: ${error.message}`
+    }
+  }
+
+  /**
+   * Navigate to another room
+   */
+  async goToRoom({ roomName }) {
+    if (!this.roomManager) {
+      return `Room navigation not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const room = await this.roomManager.findRoomByName(roomName)
+      if (!room) {
+        return `Room "${roomName}" not found`
+      }
+
+      await this.roomManager.navigateToRoom(room.id)
+      return `Successfully navigated to room: ${roomName}`
+    } catch (error) {
+      return `Failed to navigate to room "${roomName}": ${error.message}`
+    }
+  }
+
+  /**
+   * Add object to current room
+   */
+  async addObject({ name, info }) {
+    if (!this.objectManager || !this.roomManager) {
+      return `Object management not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const currentRoom = this.roomManager.getCurrentRoom()
+      if (!currentRoom) {
+        return `No current room to add object to`
+      }
+
+      await this.objectManager.createObject({
+        name,
+        info,
+        roomId: currentRoom.id,
+        position: { x: 0, y: 0, z: 0 } // Default position
+      })
+
+      return `Successfully added object "${name}" with info: ${info}`
+    } catch (error) {
+      return `Failed to add object "${name}": ${error.message}`
+    }
+  }
+
+  /**
+   * Remove object from current room
+   */
+  async removeObject({ name }) {
+    if (!this.objectManager || !this.roomManager) {
+      return `Object management not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const currentRoom = this.roomManager.getCurrentRoom()
+      if (!currentRoom) {
+        return `No current room to remove object from`
+      }
+
+      const object = await this.objectManager.findObjectByName(name, currentRoom.id)
+      if (!object) {
+        return `Object "${name}" not found in current room`
+      }
+
+      await this.objectManager.deleteObject(object.id)
+      return `Successfully removed object: ${name}`
+    } catch (error) {
+      return `Failed to remove object "${name}": ${error.message}`
+    }
+  }
+
+  /**
+   * List all available rooms
+   */
+  async listRooms() {
+    if (!this.roomManager) {
+      return `Room listing not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const rooms = await this.roomManager.getAllRooms()
+      
+      if (rooms.length === 0) {
+        return `No rooms found in your memory palace`
+      }
+
+      const roomList = rooms.map(room => 
+        `- ${room.name}: ${room.description}`
+      ).join('\n')
+
+      return `Available rooms in your memory palace:\n${roomList}`
+    } catch (error) {
+      return `Failed to list rooms: ${error.message}`
+    }
+  }
+
+  /**
+   * Get information about current room
+   */
+  async getRoomInfo() {
+    if (!this.roomManager || !this.objectManager) {
+      return `Room info not available - Memory Palace core not initialized`
+    }
+
+    try {
+      const currentRoom = this.roomManager.getCurrentRoom()
+      if (!currentRoom) {
+        return `No current room`
+      }
+
+      const objects = await this.objectManager.getObjectsInRoom(currentRoom.id)
+      
+      let info = `Current room: ${currentRoom.name}\n`
+      info += `Description: ${currentRoom.description}\n`
+      
+      if (objects.length > 0) {
+        info += `\nObjects in this room:\n`
+        info += objects.map(obj => `- ${obj.name}: ${obj.info}`).join('\n')
+      } else {
+        info += `\nNo objects in this room`
+      }
+
+      return info
+    } catch (error) {
+      return `Failed to get room info: ${error.message}`
+    }
+  }
+
+  /**
+   * Get tool definitions for Claude
+   */
+  static getToolDefinitions() {
+    return [
+      {
+        name: 'create_room',
+        description: 'Create a new memory room in the palace',
+        input_schema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Name of the new room'
+            },
+            description: {
+              type: 'string', 
+              description: 'Detailed description of the room for image generation and memory association'
+            }
+          },
+          required: ['name', 'description']
+        }
+      },
+      {
+        name: 'edit_room',
+        description: 'Modify the description of the current room',
+        input_schema: {
+          type: 'object',
+          properties: {
+            description: {
+              type: 'string',
+              description: 'Updated detailed room description'
+            }
+          },
+          required: ['description']
+        }
+      },
+      {
+        name: 'go_to_room',
+        description: 'Navigate to another room in the memory palace',
+        input_schema: {
+          type: 'object',
+          properties: {
+            roomName: {
+              type: 'string',
+              description: 'Name of the room to navigate to'
+            }
+          },
+          required: ['roomName']
+        }
+      },
+      {
+        name: 'add_object',
+        description: 'Add a memory object to the current room',
+        input_schema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Name of the memory object'
+            },
+            info: {
+              type: 'string',
+              description: 'Information or memory to associate with this object'
+            }
+          },
+          required: ['name', 'info']
+        }
+      },
+      {
+        name: 'remove_object',
+        description: 'Remove an object from the current room',
+        input_schema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Name of the object to remove'
+            }
+          },
+          required: ['name']
+        }
+      },
+      {
+        name: 'list_rooms',
+        description: 'List all available rooms in the memory palace',
+        input_schema: {
+          type: 'object',
+          properties: {}
+        }
+      },
+      {
+        name: 'get_room_info',
+        description: 'Get detailed information about the current room and its objects',
+        input_schema: {
+          type: 'object',
+          properties: {}
+        }
+      }
+    ]
+  }
+}
+
+export default MemoryPalaceToolManager


### PR DESCRIPTION
Implements proper Anthropic SDK integration with browser headers and streaming support for Memory Palace.

## Changes
- Add official @anthropic-ai/sdk dependency
- Create useAnthropicStream hook with proper browser configuration
- Add anthropic-dangerous-direct-browser-access header support
- Implement full streaming with live block updates
- Create MemoryPalaceToolManager for tool call integration
- Add 7 memory palace tools (create_room, edit_room, etc.)
- Mark legacy AnthropicAPI as deprecated

 #22

Generated with [Claude Code](https://claude.ai/code)