### PR TITLE
feat: add vercel build command with correct base path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:vercel": "vite build --base=/",
     "preview": "vite preview",
     "deploy": "npm run build && gh-pages -d dist"
   },


### PR DESCRIPTION
Fixes asset path issues when deploying to Vercel by adding a dedicated build script that uses base path "/" instead of "/Palais-de-Memoire/".

Closes #31

Generated with [Claude Code](https://claude.ai/code)