### PR TITLE
fix: resolve React StrictMode race condition in creation mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -577,8 +577,8 @@ function App() {
       memoryPalaceCoreRunning: memoryPalaceCore?.isRunning
     })
     
-    // Check if core initialization is complete using the ref
-    if (!coreInitializationRef.current || !memoryPalaceCore) {
+    // Check if core initialization is complete using state
+    if (!coreInitialized || !memoryPalaceCore) {
       console.warn('[App] Memory Palace Core not initialized, cannot enter creation mode')
       console.warn('[App] Debug info:', {
         memoryPalaceCore: !!memoryPalaceCore,


### PR DESCRIPTION
Replace ref+state checking with consistent state-only checking in `handleCreationModeTriggered`. This addresses the exact issue React StrictMode is designed to catch - inconsistent state management during component re-renders.

## Problem
- Mixed `coreInitializationRef.current` (ref) and `memoryPalaceCore` (state) checking
- Ref survives StrictMode unmounts, state doesn't, causing inconsistency
- Double-tap creation mode exits because `!true || !null = true`

## Solution
- Use only `coreInitialized` (state) for consistent checking
- Properly handles React StrictMode's intentional double-rendering
- Works identically in development and production

## Changes
- Fixed `src/App.jsx:581` - replaced ref+state check with state-only check
- Updated comment to reflect proper state-based checking

Closes #37

Generated with [Claude Code](https://claude.ai/code)