### PR TITLE
feat: Change voice input from tap-and-hold to tap-to-start/tap-to-cancel

### DIFF
--- a/src/components/MobileInterface.jsx
+++ b/src/components/MobileInterface.jsx
@@ -68,7 +68,7 @@ const MobileInterface = ({ voiceEnabled, onVoiceToggle }) => {
           </div>
           
           <div className="menu-footer">
-            <p>Tap and hold to speak, or use the command buttons above.</p>
+            <p>Tap to speak, tap again to cancel, or use the command buttons above.</p>
           </div>
         </div>
       )}

--- a/src/components/VoiceInterface.jsx
+++ b/src/components/VoiceInterface.jsx
@@ -539,10 +539,6 @@ const VoiceInterface = ({ enabled, isMobile, onCommand, onListeningChange, onCap
   }
 
   const startListening = async () => {
-    // console.log("Testing")
-    // const resp = await processCommand("testing voice")
-    // console.log(resp)
-    // return;
     console.log('[VoiceInterface] Attempting to start listening:', {
       hasRecognition: !!recognitionRef.current,
       enabled,
@@ -578,6 +574,15 @@ const VoiceInterface = ({ enabled, isMobile, onCommand, onListeningChange, onCap
     setIsListening(false)
     if (false && onListeningChange) {
       onListeningChange(false)
+    }
+  }
+
+  const toggleListening = () => {
+    console.log('[VoiceInterface] Toggling voice input - currently listening:', isListening)
+    if (isListening) {
+      stopListening()
+    } else {
+      startListening()
     }
   }
 
@@ -674,11 +679,8 @@ const VoiceInterface = ({ enabled, isMobile, onCommand, onListeningChange, onCap
       {/* Voice Control Button */}
       <button
         className={`voice-control ${isListening ? 'listening' : ''} ${isProcessing ? 'processing' : ''}`}
-        onMouseDown={startListening}
-        onMouseUp={stopListening}
-        onTouchStart={startListening}
-        onTouchEnd={stopListening}
-        aria-label="Hold to speak"
+        onClick={toggleListening}
+        aria-label={isListening ? 'Tap to cancel' : 'Tap to speak'}
         disabled={isProcessing}
       >
         <FontAwesomeIcon 
@@ -687,7 +689,7 @@ const VoiceInterface = ({ enabled, isMobile, onCommand, onListeningChange, onCap
           spin={isProcessing}
         />
         <span className="voice-control-text">
-          {isProcessing ? 'Processing...' : (isListening ? 'Listening...' : 'Hold to speak')}
+          {isProcessing ? 'Processing...' : (isListening ? 'Tap to cancel' : 'Tap to speak')}
         </span>
       </button>
 


### PR DESCRIPTION
Simplifies voice input interaction model as requested in issue #82

## Changes
- Replace hold-based events with toggle-based onClick behavior
- Add toggleListening() function for tap-to-start/tap-to-cancel
- Update button text and aria-labels to reflect new behavior
- Update mobile interface instructions
- Preserve all existing creation mode interactions

## Testing
- All tests pass (53/53)
- TypeScript compilation successful
- Build process completes without errors

Fixes #82

Generated with [Claude Code](https://claude.ai/code)