### PR TITLE
Fix build failure: Add missing getAllRooms() method to test mock

### DIFF
--- a/src/test/App.render.test.jsx
+++ b/src/test/App.render.test.jsx
@@ -137,6 +137,7 @@ vi.mock('../core/MemoryPalaceCore.js', () => ({
     on: vi.fn(), // Mock event emitter methods
     off: vi.fn(),
     emit: vi.fn(),
+    getAllRooms: vi.fn().mockReturnValue([]), // Add missing getAllRooms method
     getCurrentState: vi.fn().mockReturnValue({
       objects: [],
       rooms: [],
@@ -159,6 +160,7 @@ const createMockCore = () => ({
   on: vi.fn(),
   off: vi.fn(),
   emit: vi.fn(),
+  getAllRooms: vi.fn().mockReturnValue([]), // Add missing getAllRooms method
   getCurrentState: vi.fn().mockReturnValue({
     objects: [],
     rooms: [],


### PR DESCRIPTION
Fixes the build failure by adding the missing `getAllRooms()` method to the MemoryPalaceCore test mock.

The test was failing because the App component calls `memoryPalaceCore?.getAllRooms()` but the test mock was missing this method.

## Changes
- Added `getAllRooms: vi.fn().mockReturnValue([])` to MemoryPalaceCore test mock
- Updated both mock declaration and createMockCore function

## Verification
- All 53 tests now pass
- TypeScript type checking passes
- Vite build completes successfully

Fixes #107

Generated with [Claude Code](https://claude.ai/code)