### PR TITLE
Consolidate room and door creation tools

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -394,10 +394,9 @@ function App({core}) {
     }
     
     // Handle form-based actions
-    const formActions = ['create-room', 'edit-room', 'go-to-room', 'add-object', 'remove-object']
+    const formActions = ['edit-room', 'go-to-room', 'add-object', 'remove-object']
     if (formActions.includes(command)) {
       const actionMap = {
-        'create-room': 'create_room',
         'edit-room': 'edit_room', 
         'go-to-room': 'go_to_room',
         'add-object': 'add_object',
@@ -567,22 +566,7 @@ function App({core}) {
     try {
       // Handle different command types with actual core operations
       switch (command.type.toLowerCase()) {
-        case 'create_room':
-          console.log('[App] Processing CREATE_ROOM command:', command.parameters)
-          if (command.parameters.name && command.parameters.description) {
-            const room = await memoryPalaceCore.createRoom(
-              command.parameters.name,
-              command.parameters.description
-            )
-            console.log('[App] Room created successfully:', room)
-            updatePalaceState(memoryPalaceCore)
-            
-            // Exit creation mode if this was triggered by creation mode
-            if (isCreationMode) {
-              handleCreationModeComplete()
-            }
-          }
-          break
+        // create_room is now handled only through the create_door tool
         
         case 'add_object':
           console.log('[App] Processing ADD_OBJECT command:', command.parameters)
@@ -696,7 +680,7 @@ function App({core}) {
             lowercaseType: command.type.toLowerCase(),
             parameters: command.parameters,
             availableCommands: [
-              'create_room', 'add_object', 'remove_object', 'go_to_room', 
+              'create_door', 'add_object', 'remove_object', 'go_to_room', 
               'edit_room', 'list_rooms', 'get_room_info', 'response', 'fallback'
             ]
           })

--- a/src/components/ActionFormModal.jsx
+++ b/src/components/ActionFormModal.jsx
@@ -24,8 +24,6 @@ const ActionFormModal = ({
 
   const getDefaultFormData = (action, state) => {
     switch (action) {
-      case 'create_room':
-        return { name: '', description: '' }
       case 'edit_room':
         return { description: state?.currentRoom?.description || '' }
       case 'go_to_room':
@@ -41,14 +39,6 @@ const ActionFormModal = ({
 
   const getActionConfig = (action) => {
     const configs = {
-      create_room: {
-        title: 'Create New Room',
-        description: 'Create a new room in your memory palace',
-        fields: [
-          { key: 'name', label: 'Room Name', type: 'text', required: true, placeholder: 'Enter room name...' },
-          { key: 'description', label: 'Room Description', type: 'textarea', required: true, placeholder: 'Describe the room in detail for image generation...' }
-        ]
-      },
       edit_room: {
         title: 'Edit Current Room',
         description: 'Update the description of your current room',

--- a/src/hooks/useAnthropicStream.js
+++ b/src/hooks/useAnthropicStream.js
@@ -117,7 +117,8 @@ export const useAnthropicStream = (onAddMessage, memoryPalaceCore = null, voiceI
           contextPrompt += `  Type: ${area.paintedType || 'objects'}\n`
         })
         contextPrompt += `IMPORTANT: Consider these painted dimensions when creating objects - the user has visually indicated their intended size and placement.\n`
-        contextPrompt += `Use the painted area dimensions to inform your object creation decisions and ensure objects match the user's visual intentions.\n`
+        contextPrompt += `When using add_object_at_position or create_door tools, include the dimensions parameter with the painted area's width and height values.\n`
+        contextPrompt += `Example: dimensions: { width: 150, height: 200 } based on the painted area data above.\n`
       }
       
       contextPrompt += `\n`
@@ -151,14 +152,14 @@ export const useAnthropicStream = (onAddMessage, memoryPalaceCore = null, voiceI
 
     contextPrompt += `
 MEMORY PALACE TOOLS AVAILABLE:
-- create_door: Create a door/connection that leads to a new room (automatically creates room and bidirectional connections)
+- create_door: Create a door/connection that leads to a new room (automatically creates room and bidirectional connections). Accepts optional dimensions parameter.
 - edit_room: Modify current room's description  
 - go_to_room: Navigate to another existing room by name
 - add_object: Add a memory object to the current room
 - remove_object: Remove an object from the current room
 - list_rooms: Show all available rooms with current room marked
 - get_room_info: Get detailed info about current room and its objects
-- add_object_at_position: Add memory object at specific spatial coordinates (for creation mode)
+- add_object_at_position: Add memory object at specific spatial coordinates (for creation mode). Accepts optional dimensions parameter.
 - narrate: Speak text aloud with speech synthesis and closed captions
 
 CRITICAL NARRATION INSTRUCTIONS:

--- a/src/hooks/useAnthropicStream.js
+++ b/src/hooks/useAnthropicStream.js
@@ -102,7 +102,7 @@ export const useAnthropicStream = (onAddMessage, memoryPalaceCore = null, voiceI
       contextPrompt += `The user has DOUBLE-CLICKED on the skybox at position (${creationPosition.x.toFixed(2)}, ${creationPosition.y.toFixed(2)}, ${creationPosition.z.toFixed(2)}).\n`
       contextPrompt += `They want to create something at this specific location. Listen to their description and determine:\n`
       contextPrompt += `- If it's a MEMORY OBJECT (furniture, items, decorations, books, etc.) → use add_object_at_position\n`
-      contextPrompt += `- If it's a DOOR/PASSAGE (doorway, portal, stairs, window to another room) → use create_door_at_position\n`
+      contextPrompt += `- If it's a DOOR/PASSAGE (doorway, portal, stairs, window to another room) → use create_door\n`
       contextPrompt += `IMPORTANT: Use the exact position coordinates provided in the creationPosition for the spatial tools.\n`
       
       // Add painted area context if available
@@ -151,7 +151,7 @@ export const useAnthropicStream = (onAddMessage, memoryPalaceCore = null, voiceI
 
     contextPrompt += `
 MEMORY PALACE TOOLS AVAILABLE:
-- create_room: Create a new memory room with name and description
+- create_door: Create a door/connection that leads to a new room (automatically creates room and bidirectional connections)
 - edit_room: Modify current room's description  
 - go_to_room: Navigate to another existing room by name
 - add_object: Add a memory object to the current room
@@ -159,7 +159,6 @@ MEMORY PALACE TOOLS AVAILABLE:
 - list_rooms: Show all available rooms with current room marked
 - get_room_info: Get detailed info about current room and its objects
 - add_object_at_position: Add memory object at specific spatial coordinates (for creation mode)
-- create_door_at_position: Create door/connection at specific spatial coordinates (for creation mode)
 - narrate: Speak text aloud with speech synthesis and closed captions
 
 CRITICAL NARRATION INSTRUCTIONS:
@@ -176,10 +175,10 @@ AESTHETIC STYLE:
 
 IMPORTANT GUIDELINES:
 - Always use tools to perform actions rather than just describing them
-- If user wants to create something, use create_room or add_object tools
+- If user wants to create a door/room, use create_door tool which automatically creates both room and connections
 - If user wants to go somewhere, use go_to_room tool
 - If user asks about current state, use get_room_info or list_rooms tools
-- In CREATION MODE: Use spatial tools (add_object_at_position or create_door_at_position) with the provided coordinates
+- In CREATION MODE: Use spatial tools (add_object_at_position or create_door) with the provided coordinates
 - Be conversational and helpful while taking concrete actions
 - Encourage exploration and memory association techniques
 - If a tool fails due to initialization issues, inform the user that the system is still initializing and to try again in a moment
@@ -188,6 +187,8 @@ CREATION MODE DECISION LOGIC:
 When in creation mode, analyze the user's description:
 - Objects: furniture, decorations, books, paintings, sculptures, plants, tools, personal items
 - Doors: doorways, passages, stairs, windows leading elsewhere, portals, archways, gates
+
+NOTE: The create_door tool is the ONLY way to create new rooms - rooms can only be created through door connections.
 
 Use these tools actively to help users build and navigate their memory palace.`
 
@@ -240,8 +241,8 @@ Use these tools actively to help users build and navigate their memory palace.`
       // Fallback responses when memory palace core is not available
       console.log('[useAnthropicStream] Fallback responses when memory palace core is not available')
       switch (toolName) {
-        case 'create_room':
-          return `Room creation scheduled: "${input.name}" with description: ${input.description}. Memory Palace core not connected.`
+        case 'create_door':
+          return `Door creation scheduled: "${input.description}" leading to "${input.targetRoomName}". Memory Palace core not connected.`
         
         case 'edit_room':
           return `Room editing scheduled: ${input.description}. Memory Palace core not connected.`

--- a/src/utils/memoryPalaceTools.js
+++ b/src/utils/memoryPalaceTools.js
@@ -63,7 +63,7 @@ export class MemoryPalaceToolManager {
    * Handles both object conversion and new door creation
    * Automatically creates target room and bidirectional connections
    */
-  async createDoor({ description, targetRoomName, targetRoomDescription, position, objectId }) {
+  async createDoor({ description, targetRoomName, targetRoomDescription, position, dimensions, objectId }) {
     try {
       const currentRoom = this.core.getCurrentRoom()
       if (!currentRoom) {
@@ -76,6 +76,12 @@ export class MemoryPalaceToolManager {
 
       let doorPosition = position
       let doorDescription = description || `Door to ${targetRoomName}`
+      
+      // Log dimension information if provided
+      if (dimensions) {
+        console.log(`[createDoor] Creating door with dimensions:`, dimensions)
+        doorDescription += ` (${dimensions.width}×${dimensions.height} world units)`
+      }
       
       // Handle object conversion scenario
       if (objectId) {
@@ -211,7 +217,7 @@ export class MemoryPalaceToolManager {
   /**
    * Add object at specific position (for creation mode)
    */
-  async addObjectAtPosition({ name, info, position }) {
+  async addObjectAtPosition({ name, info, position, dimensions }) {
     try {
       const currentRoom = this.core.getCurrentRoom()
       if (!currentRoom) {
@@ -222,6 +228,12 @@ export class MemoryPalaceToolManager {
         return `Position is required for spatial object creation`
       }
 
+      // Log dimension information if provided
+      if (dimensions) {
+        console.log(`[addObjectAtPosition] Creating object with dimensions:`, dimensions)
+        info += ` (Size: ${dimensions.width}×${dimensions.height} world units)`
+      }
+      
       const object = await this.core.addObject(name, info, position)
       return `Successfully created object "${name}" at the clicked location with info: ${info}`
     } catch (error) {
@@ -461,6 +473,15 @@ export class MemoryPalaceToolManager {
                 z: { type: 'number' }
               },
               required: ['x', 'y', 'z']
+            },
+            dimensions: {
+              type: 'object',
+              description: 'Optional object dimensions from painted areas',
+              properties: {
+                width: { type: 'number', description: 'Width in world units' },
+                height: { type: 'number', description: 'Height in world units' }
+              },
+              required: ['width', 'height']
             }
           },
           required: ['name', 'info', 'position']
@@ -484,6 +505,15 @@ export class MemoryPalaceToolManager {
                 z: { type: 'number' }
               },
               required: ['x', 'y', 'z']
+            },
+            dimensions: {
+              type: 'object',
+              description: 'Optional door dimensions from painted areas',
+              properties: {
+                width: { type: 'number', description: 'Width in world units' },
+                height: { type: 'number', description: 'Height in world units' }
+              },
+              required: ['width', 'height']
             },
             objectId: { type: 'string', description: 'ID of existing object to convert to door (alternative to position)' }
           },


### PR DESCRIPTION
Consolidates room and door creation into a unified `create_door` tool as requested in issue #113.

## Changes
- Replace `create_room` and `create_door_at_position` with single `create_door` tool
- Support both object conversion and new door creation
- Automatically create target rooms and bidirectional connections
- Update system prompts and remove legacy form handling
- Ensure rooms can only be created through door connections

Closes #113

Generated with [Claude Code](https://claude.ai/code)