### PR TITLE
refactor: simplify caption handling and remove unnecessary refs

### DIFF
--- a/src/components/VoiceInterface.jsx
+++ b/src/components/VoiceInterface.jsx
@@ -17,7 +17,6 @@ const VoiceInterface = ({ enabled, speakResponse, isMobile, onCommand, onListeni
   const [showTextInput, setShowTextInput] = useState(false)
   const [conversationHistory, setConversationHistory] = useState([])
   const recognitionRef = useRef(null)
-  const captionTimeoutRef = useRef(null)
   
   // Initialize Anthropic streaming hook with memory palace core and voice interface
   // Ensure we only pass the core if it's properly initialized
@@ -164,9 +163,6 @@ const VoiceInterface = ({ enabled, speakResponse, isMobile, onCommand, onListeni
     return () => {
       if (recognitionRef.current) {
         recognitionRef.current.abort()
-      }
-      if (captionTimeoutRef.current) {
-        clearTimeout(captionTimeoutRef.current)
       }
       settingsManager.removeEventListener(handleSettingsChange)
     }


### PR DESCRIPTION
## Summary
- simplify App initialization to avoid ref-based cancellation
- manage caption timers with `useEffect` instead of `useRef`
- drop unused caption timeout ref from VoiceInterface

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a471113a44832eb14ef0195ad903d7