### PR TITLE
feat: add basic inventory system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Palais-de-Memoire
 Palais de Mémoire deploys to http://www.christopherdebeer.com/Palais-de-Memoire/
+
+## Features
+
+- Build rooms and place memory objects within them
+- **Inventory**: pick up objects with the `pickup_object` tool and carry them between rooms

--- a/src/core/MemoryPalaceCore.js
+++ b/src/core/MemoryPalaceCore.js
@@ -4,6 +4,7 @@ import * as stateUtils from '../utils/stateUtils.js'
 import * as roomUtils from '../utils/roomUtils.js'
 import * as objectUtils from '../utils/objectUtils.ts'
 import * as imageGeneration from '../utils/imageGeneration.js'
+import * as inventoryUtils from '../utils/inventoryUtils.ts'
 
 /**
  * MemoryPalaceCore - Orchestrates the Memory Palace application
@@ -369,12 +370,23 @@ export class MemoryPalaceCore extends EventEmitter {
   async deleteObject(objectId) {
     const object = objectUtils.getObject(this.state, objectId)
     const success = await objectUtils.deleteObject(this.state, objectId)
-    
+
     if (success) {
       this.emit(EventTypes.OBJECT_DELETED, { objectId, object })
     }
-    
+
     return success
+  }
+
+  /**
+   * Add an object to the user's inventory
+   */
+  async addObjectToInventory(objectId) {
+    const object = await inventoryUtils.addToInventory(this.state, objectId)
+    if (object) {
+      this.emit(EventTypes.OBJECT_UPDATED, object)
+    }
+    return object
   }
 
   /**

--- a/src/test/inventoryUtils.test.ts
+++ b/src/test/inventoryUtils.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { addToInventory, placeFromInventory, getInventory } from '../utils/inventoryUtils.js'
+import { ensureDefaultState, generateId } from '../utils/stateUtils.js'
+import { ObjectType } from '../types/index.js'
+
+// Stub localStorage for tests
+const mockStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {}
+}
+
+describe('inventory utilities', () => {
+  let state: any
+  let objectId: string
+  let roomId: string
+
+  beforeEach(() => {
+    // @ts-ignore
+    globalThis.localStorage = mockStorage
+
+    state = ensureDefaultState({
+      user: null,
+      rooms: new Map(),
+      objects: new Map(),
+      connections: new Map(),
+      conversationHistory: []
+    })
+
+    roomId = generateId()
+    state.rooms.set(roomId, {
+      id: roomId,
+      name: 'Room',
+      description: '',
+      imageUrl: null,
+      roomCounter: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    })
+    state.user.currentRoomId = roomId
+
+    objectId = generateId()
+    state.objects.set(objectId, {
+      id: objectId,
+      roomId,
+      userId: state.user.id,
+      name: 'Test Object',
+      position: { x: 0, y: 0, z: 0 },
+      objectCounter: 1,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      type: ObjectType.OBJECT,
+      information: ''
+    })
+  })
+
+  it('adds object to inventory', async () => {
+    await addToInventory(state, objectId)
+    expect(state.user.inventory).toContain(objectId)
+    expect(state.objects.get(objectId)?.roomId).toBeNull()
+  })
+
+  it('places object from inventory into room', async () => {
+    await addToInventory(state, objectId)
+    await placeFromInventory(state, objectId, roomId, { x: 1, y: 0, z: 0 })
+    expect(state.user.inventory).not.toContain(objectId)
+    const obj = state.objects.get(objectId)
+    expect(obj?.roomId).toBe(roomId)
+    expect(obj?.position.x).toBe(1)
+  })
+
+  it('getInventory lists stored objects', async () => {
+    await addToInventory(state, objectId)
+    const inv = getInventory(state)
+    expect(inv.length).toBe(1)
+    expect(inv[0]?.id).toBe(objectId)
+  })
+})
+

--- a/src/test/pickupObjectTool.test.ts
+++ b/src/test/pickupObjectTool.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import MemoryPalaceCore from '../core/MemoryPalaceCore.js'
+import MemoryPalaceToolManager from '../utils/memoryPalaceTools.js'
+import { ensureDefaultState, generateId } from '../utils/stateUtils.js'
+import { ObjectType } from '../types/index.js'
+
+// Stub localStorage for tests
+const mockStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {}
+}
+
+describe('pickup_object tool', () => {
+  let core: any
+  let tool: any
+  let objectId: string
+
+  beforeEach(() => {
+    // @ts-ignore
+    globalThis.localStorage = mockStorage
+
+    core = new MemoryPalaceCore({ enableImageGeneration: false })
+    core.state = ensureDefaultState(core.state)
+    core.isInitialized = true
+
+    const roomId = generateId()
+    const now = new Date().toISOString()
+    core.state.rooms.set(roomId, {
+      id: roomId,
+      name: 'Room',
+      description: '',
+      imageUrl: null,
+      roomCounter: 1,
+      createdAt: now,
+      updatedAt: now
+    })
+    core.state.user.currentRoomId = roomId
+
+    objectId = generateId()
+    core.state.objects.set(objectId, {
+      id: objectId,
+      roomId,
+      userId: core.state.user.id,
+      name: 'Key',
+      position: { x: 0, y: 0, z: 0 },
+      objectCounter: 1,
+      createdAt: now,
+      updatedAt: now,
+      type: ObjectType.OBJECT,
+      information: ''
+    })
+
+    tool = new MemoryPalaceToolManager(core)
+  })
+
+  it('moves object from room to inventory', async () => {
+    const message = await tool.executeTool('pickup_object', { name: 'Key' })
+    expect(message).toContain('Picked up')
+    expect(core.state.user.inventory).toContain(objectId)
+    expect(core.state.objects.get(objectId)?.roomId).toBeNull()
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,7 +81,7 @@ export interface PaintedArea {
  */
 export interface BaseMemoryObject {
   id: string;
-  roomId: string;
+  roomId: string | null;
   userId?: string;
   name: string;
   position: Vector3;
@@ -174,6 +174,7 @@ export interface UserState {
   currentRoomId: string | null;
   objectCounter: number;
   roomCounter: number;
+  inventory: string[];
   settings?: Record<string, any>;
 }
 

--- a/src/utils/inventoryUtils.ts
+++ b/src/utils/inventoryUtils.ts
@@ -1,0 +1,65 @@
+import { ApplicationState, MemoryPalaceObject, Position3D } from '../types/index.js'
+import { saveState } from './stateUtils.js'
+
+/**
+ * Add an object to the user's inventory
+ */
+export async function addToInventory(
+  state: ApplicationState,
+  objectId: string
+): Promise<MemoryPalaceObject | null> {
+  const object = state.objects.get(objectId)
+  if (!object) {
+    return null
+  }
+
+  if (!state.user.inventory.includes(objectId)) {
+    state.user.inventory.push(objectId)
+  }
+
+  object.roomId = null
+  object.updatedAt = new Date().toISOString()
+
+  await saveState(state)
+  return object
+}
+
+/**
+ * Place an object from inventory into a room
+ */
+export async function placeFromInventory(
+  state: ApplicationState,
+  objectId: string,
+  targetRoomId: string,
+  position: Position3D | null = null
+): Promise<MemoryPalaceObject | null> {
+  const object = state.objects.get(objectId)
+  if (!object) {
+    return null
+  }
+
+  const index = state.user.inventory.indexOf(objectId)
+  if (index === -1) {
+    return null
+  }
+
+  state.user.inventory.splice(index, 1)
+  object.roomId = targetRoomId
+  if (position) {
+    object.position = position
+  }
+  object.updatedAt = new Date().toISOString()
+
+  await saveState(state)
+  return object
+}
+
+/**
+ * Get all objects currently in the user's inventory
+ */
+export function getInventory(state: ApplicationState): MemoryPalaceObject[] {
+  return state.user.inventory
+    .map(id => state.objects.get(id) || null)
+    .filter((obj): obj is MemoryPalaceObject => obj !== null)
+}
+

--- a/src/utils/memoryPalaceTools.js
+++ b/src/utils/memoryPalaceTools.js
@@ -38,6 +38,8 @@ export class MemoryPalaceToolManager {
           return await this.addObject(input)
         case 'remove_object':
           return await this.removeObject(input)
+        case 'pickup_object':
+          return await this.pickupObject(input)
         case 'list_rooms':
           return await this.listRooms()
         case 'get_room_info':
@@ -299,10 +301,10 @@ export class MemoryPalaceToolManager {
       }
 
       const objects = this.core.getCurrentRoomObjects()
-      const object = objects.find(obj => 
+      const object = objects.find(obj =>
         obj.name.toLowerCase().includes(name.toLowerCase())
       )
-      
+
       if (!object) {
         const availableObjects = objects.map(obj => obj.name).join(', ')
         return `Object "${name}" not found in current room. Available objects: ${availableObjects || 'none'}`
@@ -312,6 +314,35 @@ export class MemoryPalaceToolManager {
       return `Successfully removed object: ${object.name}`
     } catch (error) {
       return `Failed to remove object "${name}": ${error.message}`
+    }
+  }
+
+  /**
+   * Pick up an object from the current room and add it to the inventory
+   */
+  async pickupObject({ name }) {
+    try {
+      const currentRoom = this.core.getCurrentRoom()
+      if (!currentRoom) {
+        return `No current room to pick up object from`
+      }
+
+      const objects = this.core
+        .getCurrentRoomObjects()
+        .filter(obj => obj.type !== ObjectType.DOOR)
+      const object = objects.find(obj =>
+        obj.name.toLowerCase().includes(name.toLowerCase())
+      )
+
+      if (!object) {
+        const availableObjects = objects.map(obj => obj.name).join(', ')
+        return `Object "${name}" not found in current room. Available objects: ${availableObjects || 'none'}`
+      }
+
+      await this.core.addObjectToInventory(object.id)
+      return `Picked up object "${object.name}" and added to inventory`
+    } catch (error) {
+      return `Failed to pick up object "${name}": ${error.message}`
     }
   }
 
@@ -483,6 +514,17 @@ export class MemoryPalaceToolManager {
           type: 'object',
           properties: {
             name: { type: 'string', description: 'Name of the object to remove' }
+          },
+          required: ['name']
+        }
+      },
+      {
+        name: 'pickup_object',
+        description: 'Pick up an object from the current room and store it in the inventory',
+        input_schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Name of the object to pick up' }
           },
           required: ['name']
         }

--- a/src/utils/stateUtils.js
+++ b/src/utils/stateUtils.js
@@ -97,6 +97,7 @@ export function ensureDefaultState(state) {
       currentRoomId: null,
       roomCounter: 0,
       objectCounter: 0,
+      inventory: [],
       settings: {}
     }
   }
@@ -104,6 +105,11 @@ export function ensureDefaultState(state) {
   // Ensure user has an ID
   if (!state.user.id) {
     state.user.id = generateId()
+  }
+
+  // Ensure inventory array exists
+  if (!Array.isArray(state.user.inventory)) {
+    state.user.inventory = []
   }
 
   // Initialize collections if not exist


### PR DESCRIPTION
## Summary
- add pickup_object tool to move room items into user inventory
- expose core helper for storing objects in inventory
- document inventory usage in README

## Testing
- `npm run test:run`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a790586974832ea60f5cefb81390c6